### PR TITLE
syncplay: new cask 1.7.5

### DIFF
--- a/Casks/syncplay.rb
+++ b/Casks/syncplay.rb
@@ -1,0 +1,21 @@
+cask "syncplay" do
+  version "1.7.5"
+  sha256 "7742ff6e2f4b702f8f85f142e79f6e5d9416ae45d7393a1d849f21e2fdaeecba"
+
+  url "https://github.com/Syncplay/syncplay/releases/download/v#{version}/Syncplay_#{version}.dmg",
+      verified: "github.com/Syncplay/syncplay/"
+  name "Syncplay"
+  desc "Synchronize video playback across multiple media players over the network"
+  homepage "https://syncplay.pl/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Syncplay.app"
+
+  postflight do
+    system "xattr", "-r", "-d", "com.apple.quarantine", "#{appdir}/Syncplay.app"
+  end
+end


### PR DESCRIPTION
## Summary
- Adds Syncplay 1.7.5 as a new cask
- Syncplay synchronizes video playback across multiple media players over the network
- Downloads the official DMG from GitHub Releases
- Includes `postflight` block to strip quarantine attribute
- Includes `livecheck` block for automatic version tracking

## Verification
- `brew style` — no offenses detected
- `brew audit --cask --online` — passed
- `brew install --cask` — installed and launched successfully

## Test plan
- [x] `brew style --cask Casks/syncplay.rb` passes
- [x] `brew audit --cask --online SoftwareRat/unsigned-tap/syncplay` passes
- [x] `brew install --cask SoftwareRat/unsigned-tap/syncplay` installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)