### PR TITLE
bump wine casks to the latest version

### DIFF
--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -1,12 +1,11 @@
 cask "wine-stable" do
-  version "10.0_3"
-  sha256 "af868b2ec7d5161552b4ca8596c65569aee4b9c7c09e3f76c30d9a92b6f92904"
+  version "11.0_1"
+  sha256 "b50dc50ec7f41d58b115a6b685d4d1315ba3c797bd3aa0f49213f2703cb82388"
 
   # Current winehq packages are deprecated and these are packages from
   # the new maintainers that will eventually be pushed to Winehq.
   # See https://www.winehq.org/pipermail/wine-devel/2021-July/191504.html
-  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version}/wine-stable-#{version}-osx64.tar.xz",
-      verified: "github.com/Gcenx/macOS_Wine_builds/"
+  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version}/wine-stable-#{version}-osx64.tar.xz"
   name "WineHQ-stable"
   desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
@@ -38,6 +37,7 @@ cask "wine-stable" do
     "wine@staging",
   ]
   depends_on cask: "other-gstreamer-runtime"
+  depends_on :macos
 
   app "Wine Stable.app"
   binary "#{appdir}/Wine Stable.app/Contents/Resources/start/bin/appdb"

--- a/Casks/wine@devel.rb
+++ b/Casks/wine@devel.rb
@@ -1,12 +1,11 @@
 cask "wine@devel" do
-  version "11.4"
-  sha256 "3808d0d133ce0f0b9c9a0ceb3fc418d914d21be2ced8b35021e38d685fb04cb0"
+  version "11.16"
+  sha256 "6f9af818b7af6001aeed7818cb32bf0155598c5ea4e3b33380a03cf814e033cd"
 
   # Current winehq packages are deprecated and these are packages from
   # the new maintainers that will eventually be pushed to Winehq.
   # See https://www.winehq.org/pipermail/wine-devel/2021-July/191504.html
-  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version}/wine-devel-#{version}-osx64.tar.xz",
-      verified: "github.com/Gcenx/macOS_Wine_builds/"
+  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version}/wine-devel-#{version}-osx64.tar.xz"
   name "WineHQ-devel"
   desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
@@ -38,10 +37,11 @@ cask "wine@devel" do
     "wine@staging",
   ]
   depends_on cask: "gstreamer-runtime"
+  depends_on :macos
 
   app "Wine Devel.app"
-  binary "#{dir_path}/start/bin/appdb"
   dir_path = "#{appdir}/Wine Devel.app/Contents/Resources"
+  binary "#{dir_path}/start/bin/appdb"
   binary "#{dir_path}/start/bin/winehelp"
   binary "#{dir_path}/wine/bin/msidb"
   binary "#{dir_path}/wine/bin/msiexec"

--- a/Casks/wine@staging.rb
+++ b/Casks/wine@staging.rb
@@ -1,12 +1,11 @@
 cask "wine@staging" do
-  version "11.4"
-  sha256 "111a7b6b37c816aef48bf95887dc88f5601029466fefd48886a4f827e8efe19c"
+  version "11.16"
+  sha256 "cd68f230c773a761b8a0423a08c51fbe49e89b6e52246f3866898d259a4988c6"
 
   # Current winehq packages are deprecated and these are packages from
   # the new maintainers that will eventually be pushed to Winehq.
   # See https://www.winehq.org/pipermail/wine-devel/2021-July/191504.html
-  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version.major_minor}/wine-staging-#{version}-osx64.tar.xz",
-      verified: "github.com/Gcenx/macOS_Wine_builds/"
+  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version.major_minor}/wine-staging-#{version}-osx64.tar.xz"
   name "WineHQ-staging"
   desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
@@ -38,10 +37,11 @@ cask "wine@staging" do
     "wine@devel",
   ]
   depends_on cask: "gstreamer-runtime"
+  depends_on :macos
 
   app "Wine Staging.app"
-  binary "#{dir_path}/start/bin/appdb"
   dir_path = "#{appdir}/Wine Staging.app/Contents/Resources"
+  binary "#{dir_path}/start/bin/appdb"
   binary "#{dir_path}/start/bin/winehelp"
   binary "#{dir_path}/wine/bin/msidb"
   binary "#{dir_path}/wine/bin/msiexec"


### PR DESCRIPTION
## Description

Bump wine casks to the latest version
- `wine-stable`: `10.0_3` -> `11.0_1`
- `wine@staging`: `11.4` -> `11.16`
- `wine@devel`: `11.4` -> `11.16`

## Checklist

- [x] Cask file is in `Casks/` and named `<token>.rb`
- [x] `version` and `sha256` are correct for the release
- [x] `brew style --cask Casks/<token>.rb` passes locally
- [x] `brew audit --cask SoftwareRat/homebrew-unsigned-tap/<token>` passes locally
- [x] A `postflight` block removes `com.apple.quarantine` (for new casks)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
