### PR TITLE
Add autobump

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,0 +1,26 @@
+name: Autobump Formulas and Casks
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+jobs:
+  autobump:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || github.token }}
+    steps:
+      - name: Update Homebrew cask
+        uses: Markos-Th09/action-homebrew-bump-cask@v3.9.0
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN || github.token }}
+          tap: ${{ github.repository }}
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          livecheck: true
+          no_fork: true

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,26 +1,51 @@
-name: Autobump Formulas and Casks
+name: Bump casks on schedule or request
 
 on:
-  schedule:
-    - cron: "0 */6 * * *"
   workflow_dispatch:
+    inputs:
+      casks:
+        description: Custom list of casks to livecheck and bump if outdated
+        required: false
+  schedule:
+    # Every 3 hours 23 minutes past the hour
+    - cron: "23 */3 * * *"
+
+permissions:
+  contents: read
 
 jobs:
   autobump:
-    runs-on: macos-latest
     permissions:
       contents: write
       pull-requests: write
-
     env:
-      HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || github.token }}
+      HOMEBREW_DEVELOPER: 1
+    runs-on: macos-26
     steps:
-      - name: Update Homebrew cask
-        uses: Markos-Th09/action-homebrew-bump-cask@v3.9.0
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
         with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN || github.token }}
-          tap: ${{ github.repository }}
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          livecheck: true
-          no_fork: true
+          core: true
+          cask: true
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          username: ${{ (github.event_name == 'workflow_dispatch' && github.actor) || 'github-actions[bot]' }}
+
+      - name: Bump casks
+        id: autobump
+        env:
+          HOMEBREW_TEST_BOT_AUTOBUMP: 1
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CASK_REPO_WORKFLOW_TOKEN || github.token }}
+          HOMEBREW_GIT_COMMITTER_NAME: github-actions[bot]
+          HOMEBREW_GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          CASKS: ${{ inputs.casks }}
+        continue-on-error: true
+        run: |
+          BREW_BUMP=(brew bump --no-fork --open-pr --casks)
+          if [[ -z "${CASKS-}" ]]; then
+            CASKS=$(brew livecheck --casks --newer-only --quiet --tap='${{ github.repository }}')
+          fi
+          xargs "${BREW_BUMP[@]}" <<<"${CASKS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Description

Automatically bump outdated formulas using [`eugenesvk/action-homebrew-bump-cask`](https://github.com/eugenesvk/action-homebrew-bump-cask). However, this action seems to be unmaintained and has not been updated to work with the `brew trust` system,  so it should probably be forked and updated accordingly or just included as a custom action in this repo.

CI will fail until #9 is merged.

Edit: I forked it to add bugfixes

Closes #10 